### PR TITLE
update country name from Turkey to Türkiye

### DIFF
--- a/database/seeders/CountriesTableSeeder.php
+++ b/database/seeders/CountriesTableSeeder.php
@@ -266,7 +266,7 @@ class CountriesTableSeeder extends Seeder
         DB::table("countries")->insert(["code" => "TO", "name" => addslashes("Tonga"), ]);
         DB::table("countries")->insert(["code" => "TT", "name" => addslashes("Trinidad and Tobago"), ]);
         DB::table("countries")->insert(["code" => "TN", "name" => addslashes("Tunisia"), ]);
-        DB::table("countries")->insert(["code" => "TR", "name" => addslashes("Turkey"), ]);
+        DB::table("countries")->insert(["code" => "TR", "name" => addslashes("Türkiye"), ]);
         DB::table("countries")->insert(["code" => "TM", "name" => addslashes("Turkmenistan"), ]);
         DB::table("countries")->insert(["code" => "TC", "name" => addslashes("Turks and Caicos Islands (the)"), ]);
         DB::table("countries")->insert(["code" => "TV", "name" => addslashes("Tuvalu"), ]);


### PR DESCRIPTION
In December 2021, `Turkey` changed the official name to `Türkiye`. This PR reflects this update.